### PR TITLE
Linux: Fix caps file path

### DIFF
--- a/linux/Detect-CVE-2017-15361-TPM.audit
+++ b/linux/Detect-CVE-2017-15361-TPM.audit
@@ -3,7 +3,7 @@
         system: "Linux"
         type : CMD_EXEC
         description : "Detects enabled TPMs vulnerable to CVE-2017-15361"
-        cmd : "export B=/sys/class/tpm/tpm0/device/cap; ( egrep 'Manufacturer\\s*:\\s*0x49465800$' -s -q $B && egrep 'Firmware\\ version:\\s*+4\\.([12]?[0-9]\\.|3[0-3]\\.|4[0-2]\\.)|\\s5\\.([1-5]?[0-9]\\.|6[01]\\.)|\\s6\\.([1-3]?[0-9]\\.|4[012]\\.)|\\s7\\.([1-5]?[0-9]\\.|6[01]\\.)|\\s133\\.([12]?[0-9]\\.|3[0-2]\\.)|\\s149\\.([12]?[0-9]\\.|3[0-2]\\.)' -q $B ) || echo -n GOOD"
+        cmd : "export B=/sys/class/tpm/tpm0/device/caps; ( egrep 'Manufacturer\\s*:\\s*0x49465800$' -s -q $B && egrep 'Firmware\\ version:\\s*+4\\.([12]?[0-9]\\.|3[0-3]\\.|4[0-2]\\.)|\\s5\\.([1-5]?[0-9]\\.|6[01]\\.)|\\s6\\.([1-3]?[0-9]\\.|4[012]\\.)|\\s7\\.([1-5]?[0-9]\\.|6[01]\\.)|\\s133\\.([12]?[0-9]\\.|3[0-2]\\.)|\\s149\\.([12]?[0-9]\\.|3[0-2]\\.)' -q $B ) || echo -n GOOD"
         expect : ".*GOOD"
 
    </custom_item>

--- a/linux/Detect-CVE-2017-15361-TPM.sh
+++ b/linux/Detect-CVE-2017-15361-TPM.sh
@@ -6,7 +6,7 @@
 #
 ####
 # Below is the description in markdown. It is used as input to generate roff section that is at the end of this file
-# I use 
+# I use
 # awk '/# BEGIN INPUT DOCUMENTATION/{flag=1;next} /# END INPUT DOCUMENTATION/{flag=0} flag {print}' Detect-CVE-2017-15361-TPM.sh | cut -b 3- | ronn -r
 # BEGIN INPUT DOCUMENTATION
 #
@@ -45,7 +45,7 @@ if [ "$1" == '-h' ] || [ "$1" == "--help" ]; then
 fi
 
 
-if [ ! -r ${1:-/sys/class/tpm/tpm0/device/cap} ]; then
+if [ ! -r ${1:-/sys/class/tpm/tpm0/device/caps} ]; then
     echo "Could not find the TPM information file."
     echo "The TPM driver is probably not installed."
     exit 1;
@@ -113,21 +113,21 @@ MSG=$(
 		exit 0
 	    fi
 	;;
-	
+
 	149)
 	    if [ ${chipVer[1]} -le 32 ]; then
 		echo VULN
 		exit 0
 	    fi
 	;;
-	
+
 	default)
 	;;
     esac
     echo GOOD
     exit 0
-    ) < ${1:-/sys/class/tpm/tpm0/device/cap}
-   ) 
+    ) < ${1:-/sys/class/tpm/tpm0/device/caps}
+   )
 
 
 if [ "$MSG" == VULN ]; then


### PR DESCRIPTION
Currently, the Linux checks point to /sys/class/tpm/tpm0/device/cap. However, according to https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-tpm, the file's name is actually caps.